### PR TITLE
Fix invite user login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,21 @@ sail npm run dev
 ``` bash
 sail artisan dev:refresh
 ```
+This will create test users with the following credentials:
+
+| Email | Password |
+|-------|----------|
+| admin@test.com | password |
+| user@test.com | password |
+
+
+#### Setting up Mailpit
+- Ensure Mailpit is not commented out in `docker-compose.yml`
+- Visit http://localhost:8025 (or whatever you have specified in `docker-compose.yml FORWARD_MAILPIT_DASHBOARD_PORT`)
+- Update the following .env settings:
+
+``` bash
+MAIL_MAILER=smtp
+MAIL_HOST=mailpit
+MAIL_PORT=1025 # or whatever you have specified in docker-compose.yml FORWARD_MAILPIT_PORT
+```

--- a/app/Http/Middleware/EnsureOrganizationAssigned.php
+++ b/app/Http/Middleware/EnsureOrganizationAssigned.php
@@ -17,10 +17,10 @@ class EnsureOrganizationAssigned
     {
         if ($request->user()) {
             $invite = $request->user()
-            ->organizationInvites()
-            ->withoutGlobalScopes()
-            ->where('accepted_at', null)
-            ->first();
+                ->organizationInvites()
+                ->withoutGlobalScopes()
+                ->where('accepted_at', null)
+                ->first();
             if ($invite) {
                 return redirect()->route(
                     'organizations.invites.show',

--- a/app/Http/Middleware/EnsureOrganizationAssigned.php
+++ b/app/Http/Middleware/EnsureOrganizationAssigned.php
@@ -15,22 +15,26 @@ class EnsureOrganizationAssigned
      */
     public function handle(Request $request, Closure $next): Response
     {
-        if ($request->user() && ! $request->user()->current_organization_id) {
-            // assign them to the first organization in their list
-            $firstOrg = $request->user()->organizations->first();
+        if ($request->user()) {
+            $invite = $request->user()
+            ->organizationInvites()
+            ->withoutGlobalScopes()
+            ->where('accepted_at', null)
+            ->first();
+            if ($invite) {
+                return redirect()->route(
+                    'organizations.invites.show',
+                    [
+                        'organization' => $invite->organization_id,
+                        'invite' => $invite->code
+                    ]
+                );
+            }
 
-            if ($firstOrg) {
-                $request->user()->update(['current_organization_id' => $firstOrg->id]);
-            } else {
-                // if they don't have an org, check for any pending invites
-                $invite = $request->user()->organizationInvites()->first();
-                if ($invite) {
-                    return redirect()->route('organizations.invites.show',
-                        [
-                            'organization' => $invite->organization_id,
-                            'invite' => $invite->code
-                        ]
-                    );
+            if (! $request->user()->current_organization_id) {
+                $firstOrg = $request->user()->organizations->first();
+                if ($firstOrg) {
+                    $request->user()->update(['current_organization_id' => $firstOrg->id]);
                 } else {
                     return redirect()->route('organizations.create');
                 }


### PR DESCRIPTION
Previously, if a new user signs up when getting an invite, the app took user to create new org screen and didn't present invite. The EnsureOrganizationAssigned middleware needed withoutGlobalScopes on that user to show the invite on the login flow, and to show to already logged in users if added to an org.