### PR TITLE
Language translations and custom field names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.phpunit.cache
 /bootstrap/ssr
 /node_modules
+/lang/ct
 /public/build
 /public/hot
 /public/storage

--- a/app/Http/Controllers/LanguageController.php
+++ b/app/Http/Controllers/LanguageController.php
@@ -24,6 +24,11 @@ class LanguageController extends Controller
                 'name' => 'French',
                 'native_name' => 'Français',
             ],
+            [
+                'code' => 'ct',
+                'name' => 'Custom',
+                'native_name' => 'Custom',
+            ],
             // Add more languages as needed
         ];
 

--- a/app/Http/Controllers/LanguageController.php
+++ b/app/Http/Controllers/LanguageController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+
+class LanguageController extends Controller
+{
+    public function index(): JsonResponse
+    {
+        $languages = [
+            [
+                'code' => 'en',
+                'name' => 'English',
+                'native_name' => 'English',
+            ],
+            [
+                'code' => 'es',
+                'name' => 'Spanish',
+                'native_name' => 'Español',
+            ],
+            [
+                'code' => 'fr',
+                'name' => 'French',
+                'native_name' => 'Français',
+            ],
+            // Add more languages as needed
+        ];
+
+        return response()->json($languages);
+    }
+} 

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -85,4 +85,15 @@ class ProfileController extends Controller
 
         return Redirect::to('/');
     }
+
+    public function updateLanguage(Request $request)
+    {
+        $validated = $request->validate([
+            'language_preference' => ['required', 'string', 'size:2'],
+        ]);
+
+        $request->user()->update($validated);
+
+        return back();
+    }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -45,6 +45,9 @@ class HandleInertiaRequests extends Middleware
             'config' => [
                 'enable_billing' => config('subscriptions.enable_billing'),
             ],
+            'translations' => [
+                'shipments' => trans('shipments'),
+            ],
         ];
     }
 }

--- a/app/Http/Middleware/SetUserLocale.php
+++ b/app/Http/Middleware/SetUserLocale.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
+use Symfony\Component\HttpFoundation\Response;
+
+class SetUserLocale
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if ($request->user()) {
+            App::setLocale($request->user()->language_preference);
+        }
+
+        return $next($request);
+    }
+} 

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -28,6 +28,7 @@ class ProfileUpdateRequest extends FormRequest
             'photo' => ['nullable', 'image', 'mimes:jpeg,png,jpg,gif', 'max:2048'],
             'removePhoto' => ['nullable', 'boolean'],
             'timezone' => ['nullable', 'string', 'max:255'],
+            'language_preference' => ['required', 'string', 'size:2'],
         ];
     }
 }

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -32,6 +32,7 @@ class UserResource extends JsonResource
             }),
             'current_organization_id' => $this->current_organization_id,
             'timezone' => $this->timezone,
+            'language_preference' => $this->language_preference,
         ];
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -33,6 +33,7 @@ class User extends Authenticatable
         'current_organization_id',
         'profile_photo_path',
         'timezone',
+        'language_preference',
     ];
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -18,6 +18,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ])
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->web(append: [
+            \App\Http\Middleware\SetUserLocale::class,
             \App\Http\Middleware\HandleInertiaRequests::class,
             \Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class,
         ]);

--- a/database/migrations/2024_03_21_000000_add_language_preference_to_users_table.php
+++ b/database/migrations/2024_03_21_000000_add_language_preference_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('language_preference')->default('en')->after('email');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('language_preference');
+        });
+    }
+}; 

--- a/lang/en/shipments.php
+++ b/lang/en/shipments.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+    'stops' => [
+        'stop_type' => 'Stop Type',
+        'facility' => 'Facility',
+        'appointment_type' => 'Appointment Type',
+        'appointment_time' => 'Appointment Time',
+        'eta' => 'ETA',
+        'arrived_at' => 'Arrived At',
+        'loaded_at' => 'Loaded At',
+        'unloaded_at' => 'Unloaded At',
+        'left_at' => 'Left At',
+        'reference_numbers' => 'Reference Numbers',
+        'special_instructions' => 'Special Instructions',
+        'add_stop' => 'Add Stop',
+        'none' => 'None',
+        'not_set' => 'Not set',
+    ],
+]; 

--- a/lang/es/shipments.php
+++ b/lang/es/shipments.php
@@ -1,0 +1,20 @@
+<?php 
+
+return [
+    'stops' => [
+        'stop_type' => 'Tipo de Parada',
+        'facility' => 'Instalación',
+        'appointment_type' => 'Tipo de Cita',
+        'appointment_time' => 'Hora de Cita',
+        'eta' => 'ETA',
+        'arrived_at' => 'Llegó a',
+        'loaded_at' => 'Cargado a',
+        'unloaded_at' => 'Descargado a',
+        'left_at' => 'Salió a',
+        'reference_numbers' => 'Números de Referencia',
+        'special_instructions' => 'Instrucciones Especiales',
+        'add_stop' => 'Agregar Parada',
+        'none' => 'Ninguno',
+        'not_set' => 'No establecido',
+    ],
+];

--- a/lang/fr/shipments.php
+++ b/lang/fr/shipments.php
@@ -1,0 +1,20 @@
+<?php 
+
+return [
+    'stops' => [
+        'stop_type' => 'Type d\'Arrêt',
+        'facility' => 'Installation',
+        'appointment_type' => 'Type de Rendez-vous',
+        'appointment_time' => 'Heure de Rendez-vous',
+        'eta' => 'ETA',
+        'arrived_at' => 'Arrivé à',
+        'loaded_at' => 'Chargé à',
+        'unloaded_at' => 'Déchargé à',
+        'left_at' => 'Parti à',
+        'reference_numbers' => 'Numéros de Référence',
+        'special_instructions' => 'Instructions Spéciales',
+        'add_stop' => 'Ajouter Arrêt',
+        'none' => 'Aucun',
+        'not_set' => 'Non défini',
+    ],
+];

--- a/resources/js/Pages/Profile/Partials/UpdateLanguageForm.tsx
+++ b/resources/js/Pages/Profile/Partials/UpdateLanguageForm.tsx
@@ -1,4 +1,3 @@
-import { useForm } from '@inertiajs/react';
 import { Button } from '@/Components/ui/button';
 import {
     Select,
@@ -8,8 +7,9 @@ import {
     SelectValue,
 } from '@/Components/ui/select';
 import { useToast } from '@/hooks/UseToast';
-import { useEffect, useState } from 'react';
+import { useForm } from '@inertiajs/react';
 import axios from 'axios';
+import { useEffect, useState } from 'react';
 
 interface Props {
     user: {
@@ -26,23 +26,24 @@ interface Language {
 export default function UpdateLanguageForm({ user }: Props) {
     const { toast } = useToast();
     const [languages, setLanguages] = useState<Language[]>([]);
-    const { data, setData, patch, processing, errors } = useForm({
+    const { data, setData, patch, processing } = useForm({
         language_preference: user.language_preference,
     });
 
     useEffect(() => {
-        axios.get<Language[]>(route('languages.index'))
-            .then(response => {
+        axios
+            .get<Language[]>(route('languages.index'))
+            .then((response) => {
                 setLanguages(response.data);
             })
-            .catch(error => {
+            .catch((error) => {
                 console.error('Failed to fetch languages:', error);
                 toast({
                     variant: 'destructive',
                     description: 'Failed to load available languages.',
                 });
             });
-    }, []);
+    }, [toast]);
 
     const submit = (e: React.FormEvent) => {
         e.preventDefault();
@@ -62,14 +63,19 @@ export default function UpdateLanguageForm({ user }: Props) {
                 <label className="text-sm font-medium">Language</label>
                 <Select
                     value={data.language_preference}
-                    onValueChange={(value) => setData('language_preference', value)}
+                    onValueChange={(value) =>
+                        setData('language_preference', value)
+                    }
                 >
                     <SelectTrigger>
                         <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
                         {languages.map((language) => (
-                            <SelectItem key={language.code} value={language.code}>
+                            <SelectItem
+                                key={language.code}
+                                value={language.code}
+                            >
                                 {language.native_name}
                             </SelectItem>
                         ))}
@@ -82,4 +88,4 @@ export default function UpdateLanguageForm({ user }: Props) {
             </div>
         </form>
     );
-} 
+}

--- a/resources/js/Pages/Profile/Partials/UpdateLanguageForm.tsx
+++ b/resources/js/Pages/Profile/Partials/UpdateLanguageForm.tsx
@@ -1,0 +1,85 @@
+import { useForm } from '@inertiajs/react';
+import { Button } from '@/Components/ui/button';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/Components/ui/select';
+import { useToast } from '@/hooks/UseToast';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+
+interface Props {
+    user: {
+        language_preference?: string;
+    };
+}
+
+interface Language {
+    code: string;
+    name: string;
+    native_name: string;
+}
+
+export default function UpdateLanguageForm({ user }: Props) {
+    const { toast } = useToast();
+    const [languages, setLanguages] = useState<Language[]>([]);
+    const { data, setData, patch, processing, errors } = useForm({
+        language_preference: user.language_preference,
+    });
+
+    useEffect(() => {
+        axios.get<Language[]>(route('languages.index'))
+            .then(response => {
+                setLanguages(response.data);
+            })
+            .catch(error => {
+                console.error('Failed to fetch languages:', error);
+                toast({
+                    variant: 'destructive',
+                    description: 'Failed to load available languages.',
+                });
+            });
+    }, []);
+
+    const submit = (e: React.FormEvent) => {
+        e.preventDefault();
+
+        patch(route('profile.language'), {
+            onSuccess: () => {
+                toast({
+                    description: 'Language preference updated successfully.',
+                });
+            },
+        });
+    };
+
+    return (
+        <form onSubmit={submit} className="space-y-6">
+            <div>
+                <label className="text-sm font-medium">Language</label>
+                <Select
+                    value={data.language_preference}
+                    onValueChange={(value) => setData('language_preference', value)}
+                >
+                    <SelectTrigger>
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {languages.map((language) => (
+                            <SelectItem key={language.code} value={language.code}>
+                                {language.native_name}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            </div>
+
+            <div className="flex items-center gap-4">
+                <Button disabled={processing}>Save</Button>
+            </div>
+        </form>
+    );
+} 

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.tsx
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.tsx
@@ -14,9 +14,9 @@ import {
 import { Timezone } from '@/types';
 import { Transition } from '@headlessui/react';
 import { Link, useForm, usePage } from '@inertiajs/react';
+import axios from 'axios';
 import { FormEventHandler, useCallback, useEffect, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
-import axios from 'axios';
 
 interface Language {
     code: string;
@@ -39,7 +39,9 @@ export default function UpdateProfileInformation({
         user?.timezone ? [{ id: 0, name: user?.timezone }] : [],
     );
     const [languages, setLanguages] = useState<Language[]>([]);
-    const [selectedLanguage, setSelectedLanguage] = useState<string>(user.language_preference || 'en');
+    const [selectedLanguage, setSelectedLanguage] = useState<string>(
+        user.language_preference || 'en',
+    );
 
     const { data, setData, patch, errors, processing, recentlySuccessful } =
         useForm({
@@ -67,12 +69,13 @@ export default function UpdateProfileInformation({
                 setTimezones(data);
             });
 
-        axios.get<Language[]>(route('languages.index'))
-            .then(response => {
+        axios
+            .get<Language[]>(route('languages.index'))
+            .then((response) => {
                 setLanguages(response.data);
                 setSelectedLanguage(user.language_preference || 'en');
             })
-            .catch(error => {
+            .catch((error) => {
                 console.error('Failed to fetch languages:', error);
             });
     }, [user.language_preference]);
@@ -259,12 +262,17 @@ export default function UpdateProfileInformation({
                     >
                         <SelectTrigger>
                             <SelectValue>
-                                {languages.find(lang => lang.code === selectedLanguage)?.native_name || 'Select a language'}
+                                {languages.find(
+                                    (lang) => lang.code === selectedLanguage,
+                                )?.native_name || 'Select a language'}
                             </SelectValue>
                         </SelectTrigger>
                         <SelectContent>
                             {languages.map((language) => (
-                                <SelectItem key={language.code} value={language.code}>
+                                <SelectItem
+                                    key={language.code}
+                                    value={language.code}
+                                >
                                     {language.native_name}
                                 </SelectItem>
                             ))}

--- a/resources/js/Pages/Shipments/Partials/ShipmentStopsList.tsx
+++ b/resources/js/Pages/Shipments/Partials/ShipmentStopsList.tsx
@@ -24,7 +24,8 @@ import {
 } from '@/lib/timezone';
 import { ShipmentStop, TimezoneData } from '@/types';
 import { StopType } from '@/types/enums';
-import { useForm } from '@inertiajs/react';
+import { useForm, usePage } from '@inertiajs/react';
+import { PageProps as InertiaPageProps } from '@inertiajs/core';
 import {
     ArrowDown,
     ArrowUp,
@@ -41,6 +42,29 @@ type FormErrors = {
     [key: `stops.${number}.${string}`]: string;
 };
 
+interface PageProps extends InertiaPageProps {
+    translations: {
+        shipments: {
+            stops: {
+                stop_type: string;
+                facility: string;
+                appointment_type: string;
+                appointment_time: string;
+                eta: string;
+                arrived_at: string;
+                loaded_at: string;
+                unloaded_at: string;
+                left_at: string;
+                reference_numbers: string;
+                special_instructions: string;
+                add_stop: string;
+                none: string;
+                not_set: string;
+            };
+        };
+    };
+}
+
 export default function ShipmentStopsList({
     shipmentId,
     stops,
@@ -48,6 +72,8 @@ export default function ShipmentStopsList({
     shipmentId: number;
     stops: ShipmentStop[];
 }) {
+    const { translations } = usePage<PageProps>().props;
+    const t = translations.shipments.stops;
     const [editMode, setEditMode] = useState(false);
     const { toast } = useToast();
     const [timezones, setTimezones] = useState<Record<string, TimezoneData>>(
@@ -179,7 +205,7 @@ export default function ShipmentStopsList({
                                     setData('stops', updatedStops);
                                 }}
                             >
-                                Add Stop
+                                {t.add_stop}
                             </Button>
                         )}
                     </div>
@@ -275,7 +301,7 @@ export default function ShipmentStopsList({
                                         {editMode ? (
                                             <>
                                                 <label className="text-sm font-medium">
-                                                    Stop Type
+                                                    {t.stop_type}
                                                 </label>
                                                 <Select
                                                     value={stop.stop_type}
@@ -350,7 +376,7 @@ export default function ShipmentStopsList({
                                     <div>
                                         <div className="flex items-center justify-between">
                                             <label className="text-sm font-medium">
-                                                Facility
+                                                {t.facility}
                                             </label>
                                             {editMode && (
                                                 <Button
@@ -441,7 +467,7 @@ export default function ShipmentStopsList({
                                     </div>
                                     <div>
                                         <label className="text-sm font-medium text-muted-foreground">
-                                            Appointment Type
+                                            {t.appointment_type}
                                         </label>
                                         {editMode ? (
                                             <>
@@ -503,13 +529,13 @@ export default function ShipmentStopsList({
                                         ) : (
                                             <p className="capitalize">
                                                 {stop.appointment_type ||
-                                                    'Not set'}
+                                                    t.not_set}
                                             </p>
                                         )}
                                     </div>
                                     <div>
                                         <label className="text-sm font-medium">
-                                            Appointment Time
+                                            {t.appointment_time}
                                         </label>
                                         {editMode ? (
                                             <>
@@ -571,7 +597,7 @@ export default function ShipmentStopsList({
                                         <>
                                             <div>
                                                 <label className="text-sm font-medium">
-                                                    ETA
+                                                    {t.eta}
                                                 </label>
                                                 {editMode ? (
                                                     <>
@@ -639,7 +665,7 @@ export default function ShipmentStopsList({
                                             </div>
                                             <div>
                                                 <label className="text-sm font-medium">
-                                                    Arrived At
+                                                    {t.arrived_at}
                                                 </label>
                                                 {editMode ? (
                                                     <>
@@ -710,8 +736,8 @@ export default function ShipmentStopsList({
                                             <div>
                                                 <label className="text-sm font-medium">
                                                     {stop.stop_type === 'pickup'
-                                                        ? 'Loaded At'
-                                                        : 'Unloaded At'}
+                                                        ? t.loaded_at
+                                                        : t.unloaded_at}
                                                 </label>
                                                 {editMode ? (
                                                     <>
@@ -781,7 +807,7 @@ export default function ShipmentStopsList({
                                             </div>
                                             <div>
                                                 <label className="text-sm font-medium">
-                                                    Left At
+                                                    {t.left_at}
                                                 </label>
                                                 {editMode ? (
                                                     <>
@@ -851,7 +877,7 @@ export default function ShipmentStopsList({
                                     )}
                                     <div className="col-span-2">
                                         <label className="text-sm font-medium">
-                                            Reference Numbers
+                                            {t.reference_numbers}
                                         </label>
                                         {editMode ? (
                                             <>
@@ -893,13 +919,13 @@ export default function ShipmentStopsList({
                                         ) : (
                                             <p>
                                                 {stop.reference_numbers ||
-                                                    'None'}
+                                                    t.none}
                                             </p>
                                         )}
                                     </div>
                                     <div className="col-span-2">
                                         <label className="text-sm font-medium">
-                                            Special Instructions
+                                            {t.special_instructions}
                                         </label>
                                         {editMode ? (
                                             <>
@@ -941,7 +967,7 @@ export default function ShipmentStopsList({
                                         ) : (
                                             <p>
                                                 {stop.special_instructions ||
-                                                    'None'}
+                                                    t.none}
                                             </p>
                                         )}
                                     </div>

--- a/resources/js/Pages/Shipments/Partials/ShipmentStopsList.tsx
+++ b/resources/js/Pages/Shipments/Partials/ShipmentStopsList.tsx
@@ -24,8 +24,8 @@ import {
 } from '@/lib/timezone';
 import { ShipmentStop, TimezoneData } from '@/types';
 import { StopType } from '@/types/enums';
-import { useForm, usePage } from '@inertiajs/react';
 import { PageProps as InertiaPageProps } from '@inertiajs/core';
+import { useForm, usePage } from '@inertiajs/react';
 import {
     ArrowDown,
     ArrowUp,

--- a/resources/js/types/index.d.ts
+++ b/resources/js/types/index.d.ts
@@ -7,6 +7,7 @@ export interface User {
     organizations: Organization[];
     profile_photo_url?: string;
     timezone?: string;
+    language_preference?: string;
 }
 
 export type PageProps<

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,6 +61,7 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\Shipments\ShipmentController;
 use App\Http\Controllers\CustomerController;
 use App\Http\Controllers\TimezoneController;
+use App\Http\Controllers\LanguageController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -92,8 +93,10 @@ Route::get('/products', function () {
 Route::middleware('auth')->group(function () {
 
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
-    Route::post('/profile', [ProfileController::class, 'update'])->name('profile.update');
+    Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+    Route::patch('/profile/language', [ProfileController::class, 'updateLanguage'])->name('profile.language');
+    Route::get('/languages', [LanguageController::class, 'index'])->name('languages.index');
 
     Route::resource('organizations', OrganizationController::class);
 

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -17,9 +17,10 @@ test('profile information can be updated', function () {
 
     $response = $this
         ->actingAs($user)
-        ->post('/profile', [
+        ->patch('/profile', [
             'name' => 'Test User',
             'email' => 'test@example.com',
+            'language_preference' => 'en',
         ]);
 
     $response
@@ -38,9 +39,10 @@ test('email verification status is unchanged when the email address is unchanged
 
     $response = $this
         ->actingAs($user)
-        ->post('/profile', [
+        ->patch('/profile', [
             'name' => 'Test User',
             'email' => $user->email,
+            'language_preference' => 'en',
         ]);
 
     $response


### PR DESCRIPTION
Added initial support for language translations on stops fields. Future PRs can add translations to other pages/components.

This initial version creates a `ct` language for `custom` and adds it to the gitignore so the changed source isn't tracked and doesn't alter the git tree when changed. If Custom language is selected but no folder/files exist, English is defaulted to.