### PR TITLE
Move invite form div outside DialogDescription

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ aws --endpoint-url=http://localhost:4566 s3 mb s3://my-test-bucket
 aws --endpoint-url=http://localhost:4566 s3 ls s3://my-test-bucket --recursive
 ```
 
-Update your .env to reflect s3
+Update your .env to reflect s3:
 
 ```bash
 AWS_ACCESS_KEY_ID=test
@@ -112,5 +112,7 @@ AWS_ENDPOINT=http://localstack:4566
 AWS_USE_PATH_STYLE_ENDPOINT=true
 FILESYSTEM_DISK=s3
 ```
+
+As noted above, the AWS endpoint is `localstack` which is the container name that can be reached other containers within docker that are linked. However, if you are testing via the browser and try to download, you will be served with `http://localstack:4566` so one way to solve that is to edit your hosts file to point `localstack` to `127.0.0.1` the same way localhost is.
 
 

--- a/resources/js/Pages/Organizations/Partials/InvitesTable.tsx
+++ b/resources/js/Pages/Organizations/Partials/InvitesTable.tsx
@@ -291,29 +291,31 @@ export default function InvitesTable({
                                                 organization
                                             </DialogTitle>
                                             <DialogDescription>
-                                                <div className="my-4">
-                                                    <Label htmlFor="invite-email">
-                                                        Email
-                                                    </Label>
-                                                    <Input
-                                                        id="invite-email"
-                                                        type="email"
-                                                        value={data.email}
-                                                        placeholder="m@example.com"
-                                                        required
-                                                        onChange={(e) =>
-                                                            setData(
-                                                                'email',
-                                                                e.target.value,
-                                                            )
-                                                        }
-                                                    />
-                                                    <InputError
-                                                        message={errors.email}
-                                                    />
-                                                </div>
+                                                Enter the email address of the
+                                                person you'd like to invite.
                                             </DialogDescription>
                                         </DialogHeader>
+                                        <div className="my-4">
+                                            <Label htmlFor="invite-email">
+                                                Email
+                                            </Label>
+                                            <Input
+                                                id="invite-email"
+                                                type="email"
+                                                value={data.email}
+                                                placeholder="m@example.com"
+                                                required
+                                                onChange={(e) =>
+                                                    setData(
+                                                        'email',
+                                                        e.target.value,
+                                                    )
+                                                }
+                                            />
+                                            <InputError
+                                                message={errors.email}
+                                            />
+                                        </div>
                                         <DialogFooter>
                                             <Button
                                                 type="submit"


### PR DESCRIPTION
Moving the form elements out of DialogDescription: The <div> containing the form elements (Label, Input, InputError) was nested inside DialogDescription, which is typically rendered as a <p> element. This created invalid HTML since block elements like <div> cannot be nested inside <p> elements.
